### PR TITLE
fixes issue when it shows too many end time slots

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -47,6 +47,7 @@ const createService = (resourceIds) => {
         name: 'LSAT Tutoring',
         description: 'LSAT Tutoring service',
         duration: 60,
+        max_duration: 90,
         resources: resourceIds.join(',')
     };
     return new Promise((resolve, reject) => {

--- a/src/js/actions/__tests__/staff.spec.js
+++ b/src/js/actions/__tests__/staff.spec.js
@@ -20,11 +20,13 @@ describe('staff action creators', () => {
     describe('fetchStaff', () => {
         context('when invoked', () => {
             const duration = 60;
+            const maxDuration = 90;
             const resourceId = uuidv1();
             const service = {
                 body: {
                     resources: [resourceId], // resourceId returned from the service
-                    duration
+                    duration,
+                    max_duration: maxDuration
                 }
             };
             const resource = {
@@ -77,7 +79,8 @@ describe('staff action creators', () => {
                 expect(store.dispatch).to.have.been.calledWith({
                     type: STAFF_FETCHED,
                     staffMembers,
-                    duration
+                    duration,
+                    maxDuration
                 });
             });
         });

--- a/src/js/actions/staff.js
+++ b/src/js/actions/staff.js
@@ -89,6 +89,7 @@ export const fetchStaff = () =>
             const staffMembers = [];
             const resourceIds = response.body.resources;
             const duration = response.body.duration;
+            const maxDuration = response.body.max_duration;
             const promises = resourceIds.map(resourceId => (
                     request.get(`/api/resources/${resourceId}`).then((resourcesResponse) => {
                         const { id, name } = resourcesResponse.body;
@@ -99,7 +100,8 @@ export const fetchStaff = () =>
                     dispatch({
                         type: STAFF_FETCHED,
                         staffMembers,
-                        duration
+                        duration,
+                        maxDuration
                     })
                 ));
         });

--- a/src/js/reducers/__tests__/staff.spec.js
+++ b/src/js/reducers/__tests__/staff.spec.js
@@ -535,7 +535,7 @@ describe('staff reducers', () => {
             '8:30 AM', '8:45 AM', '9:00 AM'];
         const slotTime = timeSlots[0];
         const selectedStaffMember = {
-            id: '1b358118-fef1-11e7-8be5-0ed5f89f718b', // resourceId
+            id: uuidv1(), // resourceId
             imagePath: 'http://i.pravatar.cc/300?img=15',
             name: 'Phillip Fry',
             availableSlots: {
@@ -582,7 +582,7 @@ describe('staff reducers', () => {
             '8:00 AM', '8:15 AM', '8:30 AM'];
         const slotTime = timeSlots[0];
         const selectedStaffMember = {
-            id: '1b358118-fef1-11e7-8be5-0ed5f89f718b', // resourceId
+            id: uuidv1(), // resourceId
             imagePath: 'http://i.pravatar.cc/300?img=15',
             name: 'Phillip Fry',
             availableSlots: {

--- a/src/js/reducers/__tests__/staff.spec.js
+++ b/src/js/reducers/__tests__/staff.spec.js
@@ -7,7 +7,8 @@ import {
     BOOKINGS_FETCHED,
     STAFF_SELECTED,
     IS_LOADING,
-    CLEAR_AVAILABLE_SLOTS
+    CLEAR_AVAILABLE_SLOTS,
+    TIME_SLOT_SELECTED
 } from 'src/js/action-types';
 import { createNew } from 'src/js/store';
 import { initialState } from 'src/js/reducers/staff';
@@ -52,14 +53,15 @@ describe('staff reducers', () => {
     context(`${STAFF_FETCHED} is dispatched`, () => {
         let state;
         const duration = 60;
-
+        const maxDuration = 90;
         before(() => {
             const store = createNew();
             store.dispatch(
                 {
                     type: STAFF_FETCHED,
                     staffMembers,
-                    duration
+                    duration,
+                    maxDuration
                 }
             );
             state = store.getState().staff;
@@ -69,7 +71,8 @@ describe('staff reducers', () => {
             expect(state).to.eql({
                 ...initialState,
                 staffMembers,
-                duration
+                duration,
+                maxDuration
             });
         });
 
@@ -518,6 +521,104 @@ describe('staff reducers', () => {
                     }
                 }
             });
+        });
+    });
+
+    context(`when ${TIME_SLOT_SELECTED} is dispatched with startTime as slotType`, () => {
+        let state;
+        const formattedDate = '2017-04-01';
+        const selectedDate = moment(formattedDate);
+        const slotType = 'startTime';
+        const timeSlots = [
+            '7:00 AM', '7:15 AM', '7:30 AM',
+            '7:45 AM', '8:00 AM', '8:15 AM',
+            '8:30 AM', '8:45 AM', '9:00 AM'];
+        const slotTime = timeSlots[0];
+        const selectedStaffMember = {
+            id: '1b358118-fef1-11e7-8be5-0ed5f89f718b', // resourceId
+            imagePath: 'http://i.pravatar.cc/300?img=15',
+            name: 'Phillip Fry',
+            availableSlots: {
+                [formattedDate]: timeSlots
+            },
+            slotsForDate: timeSlots,
+            selectedDate
+        };
+        before(() => {
+            const store = createNew(
+                {
+                    staff: {
+                        ...initialState,
+                        selectedStaffMember
+                    }
+                }
+            );
+            store.dispatch({
+                type: TIME_SLOT_SELECTED,
+                slotTime,
+                slotType
+            });
+            state = store.getState().staff.selectedStaffMember;
+        });
+
+        it('has an updated slotsForDate with endTimes', () => {
+            expect(state).to.eql(
+                {
+                    ...selectedStaffMember,
+                    [slotType]: slotTime,
+                    slotsForDate: ['8:00 AM', '8:15 AM', '8:30 AM'],
+                    slotForm: 'end'
+                }
+            );
+        });
+    });
+
+    context(`when ${TIME_SLOT_SELECTED} is dispatched with endTime as slotType`, () => {
+        let state;
+        const formattedDate = '2017-04-01';
+        const selectedDate = moment(formattedDate);
+        const slotType = 'endTime';
+        const timeSlots = [
+            '8:00 AM', '8:15 AM', '8:30 AM'];
+        const slotTime = timeSlots[0];
+        const selectedStaffMember = {
+            id: '1b358118-fef1-11e7-8be5-0ed5f89f718b', // resourceId
+            imagePath: 'http://i.pravatar.cc/300?img=15',
+            name: 'Phillip Fry',
+            availableSlots: {
+                [formattedDate]: timeSlots
+            },
+            slotsForDate: timeSlots,
+            selectedDate,
+            startTime: '7:00 AM',
+            slotForm: 'end'
+        };
+        before(() => {
+            const store = createNew(
+                {
+                    staff: {
+                        ...initialState,
+                        selectedStaffMember
+                    }
+                }
+            );
+            store.dispatch({
+                type: TIME_SLOT_SELECTED,
+                slotTime,
+                slotType
+            });
+            state = store.getState().staff.selectedStaffMember;
+        });
+
+        it('has an updated slotType as endTime with the selected slot', () => {
+            expect(state).to.eql(
+                {
+                    ...selectedStaffMember,
+                    [slotType]: slotTime,
+                    slotsForDate: ['8:00 AM', '8:15 AM', '8:30 AM'],
+                    slotForm: 'end'
+                }
+            );
         });
     });
 });


### PR DESCRIPTION
This was never taking maxDuration into account when generating ending slot times. Now the loop that generates ending slot times ends when maxDuration is reached.